### PR TITLE
Allow CORS requests from any origin

### DIFF
--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -58,6 +58,40 @@ _CDP_SESSION_CLEANUP: Callable[[], None] | None = None
 app = Flask(__name__)
 app.json.ensure_ascii = False
 
+
+@app.before_request
+def _handle_cors_preflight():
+    """Return an empty response for CORS preflight requests."""
+
+    if request.method == 'OPTIONS':
+        response = Response(status=204)
+        response.headers['Access-Control-Allow-Origin'] = '*'
+        response.headers['Access-Control-Allow-Headers'] = (
+            request.headers.get('Access-Control-Request-Headers', '*')
+        )
+        response.headers['Access-Control-Allow-Methods'] = (
+            request.headers.get(
+                'Access-Control-Request-Method',
+                'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+            )
+        )
+        return response
+
+
+@app.after_request
+def _set_cors_headers(response: Response):
+    """Attach permissive CORS headers to all responses."""
+
+    response.headers.setdefault('Access-Control-Allow-Origin', '*')
+    response.headers.setdefault(
+        'Access-Control-Allow-Headers',
+        request.headers.get('Access-Control-Request-Headers', 'Content-Type, Authorization'),
+    )
+    response.headers.setdefault(
+        'Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS'
+    )
+    return response
+
 _message_sequence = count()
 
 


### PR DESCRIPTION
## Summary
- add a preflight handler that responds with permissive CORS headers
- attach Access-Control-Allow headers to every response so any origin can call the APIs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddde7b09e48320a0411371dd4d2a05